### PR TITLE
Fix missing Whiff% column in data tables

### DIFF
--- a/MLBstuff.R
+++ b/MLBstuff.R
@@ -157,6 +157,7 @@ stuffPlusUI <- function(id) {
         
         .data-table-container {
           margin-top: 8px;
+          overflow-x: auto;
         }
         
         table.dataTable {
@@ -695,6 +696,7 @@ stuffPlusServer <- function(id) {
         options = list(
           dom = "t",
           ordering = FALSE,
+          scrollX = TRUE,
           columnDefs = list(
             list(className = "dt-center", targets = "_all"),
             list(width = "25px", targets = 0),  # Type


### PR DESCRIPTION
## Summary
- make data table container horizontally scrollable
- allow horizontal scrolling on DataTables to keep the Whiff% column visible

## Testing
- `apt-get update` *(fails: repository access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687a5a4dc8748331905d05df6035f3b8